### PR TITLE
Bat is for windows

### DIFF
--- a/03_save_as_pfx.bat
+++ b/03_save_as_pfx.bat
@@ -1,6 +1,6 @@
 openssl x509 -inform DER -in clcert.der -outform PEM -out clcert.pem
 openssl rsa -inform DER -in privkey.der -outform PEM -out privkey.pem
-cat clcert.pem privkey.pem > nx_tls_client_cert.pem
+type clcert.pem privkey.pem > nx_tls_client_cert.pem
 openssl pkcs12 -export -in nx_tls_client_cert.pem -out nx_tls_client_cert.pfx -passout pass:switch
 md Out
 move nx_tls_client_cert.pfx Out/nx_tls_client_cert.pfx


### PR DESCRIPTION
please use the proper syntax for windows. 'cat' is linux; 'type' is windows.